### PR TITLE
set trigger(n) to n=10 in example

### DIFF
--- a/example/main.mo
+++ b/example/main.mo
@@ -227,7 +227,7 @@ actor class Example() = self {
     #seconds 60,
     func() : async () {
       for (asset in Vec.vals(assets)) {
-        await* asset.handler.trigger(1);
+        await* asset.handler.trigger(10);
       };
     },
   );


### PR DESCRIPTION
In the example we set the timer to 60 seconds. The trigger runs n sequential consolidations. Each consolidation as a cross-subnet call takes about 4-5 seconds normally. So we should be able to complete 10 in a minute. If there is a large backlog then it is better to process as much as possible of it.