### PR TITLE
Disable integrity check

### DIFF
--- a/src/AccountManager.mo
+++ b/src/AccountManager.mo
@@ -340,7 +340,7 @@ module {
         underwayFunds_ += deposit;
         let result = await* consolidate(p, release);
         underwayFunds_ -= deposit;
-        assertIntegrity();
+        // assertIntegrity();
         switch (result) {
           case (#err(#CallIcrc1LedgerError)) return;
           case (_) {};


### PR DESCRIPTION
It is currently not robust against canister upgrades and needs to be fixed later.